### PR TITLE
Add OTokenTrade entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -340,6 +340,29 @@ type ExpiryPrice @entity {
    isDisputed: Boolean!
 }
 
+type OTokenTrade @entity {
+  id: ID!
+
+  timestamp: BigInt!
+
+  "the one buying oToken"
+  buyer: Bytes!
+
+  "the one selling oToken"
+  seller: Bytes!
+
+  oToken: OToken!
+  paymentToken: ERC20!
+  transactionHash: Bytes!
+
+  oTokenAmount: BigInt!
+
+  paymentTokenAmount: BigInt!
+
+  "Name of the DEX protocol."
+  exchange: String!
+}
+
 type FillOrder @entity {
   id: ID!
   timestamp: BigInt!


### PR DESCRIPTION
This PR creates an `OTokenTrade` entity, for us to easily access an account's trade history. 

In the future as we integrate with more exchanges, we will keep merging different events into OTokenTrade, so our frontend don't have to update anything.